### PR TITLE
Upgrade dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,7 +17,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0a8acea8c2f1c60f0a92a8cd26bf96ca97db56f10bbcab238bbe0cceba659ee"
 dependencies = [
- "nom",
+ "nom 7.1.3",
  "vte",
 ]
 
@@ -162,9 +162,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -227,6 +227,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -325,7 +334,7 @@ dependencies = [
 name = "puzzle-2015-06"
 version = "0.0.0"
 dependencies = [
- "nom",
+ "nom 8.0.0",
  "ornament",
 ]
 
@@ -333,7 +342,7 @@ dependencies = [
 name = "puzzle-2015-07"
 version = "0.0.0"
 dependencies = [
- "nom",
+ "nom 8.0.0",
  "ornament",
 ]
 
@@ -341,7 +350,7 @@ dependencies = [
 name = "puzzle-2015-08"
 version = "0.0.0"
 dependencies = [
- "nom",
+ "nom 8.0.0",
  "ornament",
 ]
 
@@ -350,7 +359,7 @@ name = "puzzle-2015-09"
 version = "0.0.0"
 dependencies = [
  "itertools",
- "nom",
+ "nom 8.0.0",
  "ornament",
 ]
 
@@ -382,7 +391,7 @@ name = "puzzle-2015-13"
 version = "0.0.0"
 dependencies = [
  "itertools",
- "nom",
+ "nom 8.0.0",
  "ornament",
 ]
 
@@ -390,7 +399,7 @@ dependencies = [
 name = "puzzle-2015-14"
 version = "0.0.0"
 dependencies = [
- "nom",
+ "nom 8.0.0",
  "ornament",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,8 @@ members = ["crates/*", "puzzles/template", "puzzles/2015/*"]
 
 [workspace.dependencies]
 hex = "0.4.3"
-itertools = "0.13.0"
+itertools = "0.14.0"
 md-5 = "0.10.6"
-nom = "7.1.3"
+nom = "8.0.0"
 ornament = { path = "./crates/ornament" }
-serde_json = "1.0.133"
+serde_json = "1.0.140"

--- a/crates/ornament/Cargo.toml
+++ b/crates/ornament/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-comfy-table = { version = "7.1.3", features = ["custom_styling"] }
-owo-colors = "4.1.0"
-serde = { version = "1.0.215", features = ["derive"] }
-serde_json = "1.0.133"
+comfy-table = { version = "7.1.4", features = ["custom_styling"] }
+owo-colors = "4.2.0"
+serde = { version = "1.0.219", features = ["derive"] }
+serde_json = "1.0.140"

--- a/puzzles/2015/2015-06/src/common.rs
+++ b/puzzles/2015/2015-06/src/common.rs
@@ -5,7 +5,7 @@ use nom::{
     bytes::complete::tag,
     character::complete::digit1,
     combinator::{map, map_res},
-    sequence::tuple,
+    Parser,
 };
 
 pub struct Instruction {
@@ -37,7 +37,7 @@ impl FromStr for Instruction {
 
 fn instruction(input: &str) -> nom::IResult<&str, Instruction> {
     map(
-        tuple((
+        (
             alt((
                 map(tag("turn on"), |_| InstructionKind::Enable),
                 map(tag("turn off"), |_| InstructionKind::Disable),
@@ -47,18 +47,20 @@ fn instruction(input: &str) -> nom::IResult<&str, Instruction> {
             location,
             tag(" through "),
             location,
-        )),
+        ),
         |(kind, _, from, _, to)| Instruction { kind, from, to },
-    )(input)
+    )
+    .parse(input)
 }
 
 fn location(input: &str) -> nom::IResult<&str, Location> {
     map(
-        tuple((
+        (
             map_res(digit1, |s: &str| s.parse()),
             tag(","),
             map_res(digit1, |s: &str| s.parse()),
-        )),
+        ),
         |(x, _, y)| Location { x, y },
-    )(input)
+    )
+    .parse(input)
 }

--- a/puzzles/2015/2015-07/src/common/instruction.rs
+++ b/puzzles/2015/2015-07/src/common/instruction.rs
@@ -59,72 +59,81 @@ mod parsing {
         bytes::complete::{tag, take_while1},
         character::complete::space0,
         combinator::{map, map_res},
-        sequence::{delimited, tuple},
+        sequence::delimited,
+        Parser,
     };
 
     pub fn instruction(input: &str) -> nom::IResult<&str, Instruction> {
-        map(tuple((gate, tag("->"), wire)), |(gate, _, output)| {
-            Instruction { gate, output }
-        })(input)
+        map((gate, tag("->"), wire), |(gate, _, output)| Instruction {
+            gate,
+            output,
+        })
+        .parse(input)
     }
 
     fn gate(input: &str) -> nom::IResult<&str, Gate> {
         fn and(input: &str) -> nom::IResult<&str, Gate> {
-            map(tuple((value, tag("AND"), value)), |(a, _, b)| Gate::And {
+            map((value, tag("AND"), value), |(a, _, b)| Gate::And {
                 wires: (a, b),
-            })(input)
+            })
+            .parse(input)
         }
 
         fn connect(input: &str) -> nom::IResult<&str, Gate> {
-            map(wire, Gate::Connect)(input)
+            map(wire, Gate::Connect).parse(input)
         }
 
         fn left_shift(input: &str) -> nom::IResult<&str, Gate> {
-            map(tuple((wire, tag("LSHIFT"), number)), |(wire, _, amount)| {
+            map((wire, tag("LSHIFT"), number), |(wire, _, amount)| {
                 Gate::LeftShift { wire, amount }
-            })(input)
+            })
+            .parse(input)
         }
 
         fn or(input: &str) -> nom::IResult<&str, Gate> {
-            map(tuple((value, tag("OR"), value)), |(a, _, b)| Gate::Or {
+            map((value, tag("OR"), value), |(a, _, b)| Gate::Or {
                 wires: (a, b),
-            })(input)
+            })
+            .parse(input)
         }
 
         fn not(input: &str) -> nom::IResult<&str, Gate> {
-            map(tuple((tag("NOT"), wire)), |(_, wire)| Gate::Not(wire))(input)
+            map((tag("NOT"), wire), |(_, wire)| Gate::Not(wire)).parse(input)
         }
 
         fn right_shift(input: &str) -> nom::IResult<&str, Gate> {
-            map(tuple((wire, tag("RSHIFT"), number)), |(wire, _, amount)| {
+            map((wire, tag("RSHIFT"), number), |(wire, _, amount)| {
                 Gate::RightShift { wire, amount }
-            })(input)
+            })
+            .parse(input)
         }
 
         fn signal(input: &str) -> nom::IResult<&str, Gate> {
-            map(number, Gate::Signal)(input)
+            map(number, Gate::Signal).parse(input)
         }
 
         // `connect` must be last or it will always match other gates
         // before their respective parsers got a chances.
-        alt((and, or, not, left_shift, right_shift, signal, connect))(input)
+        alt((and, or, not, left_shift, right_shift, signal, connect)).parse(input)
     }
 
     fn value(input: &str) -> nom::IResult<&str, Value<'_>> {
-        alt((map(wire, Value::Wire), map(number, Value::Signal)))(input)
+        alt((map(wire, Value::Wire), map(number, Value::Signal))).parse(input)
     }
 
     fn wire(input: &str) -> nom::IResult<&str, Wire<'_>> {
         map(
             delimited(space0, take_while1(char::is_alphabetic), space0),
             Wire,
-        )(input)
+        )
+        .parse(input)
     }
 
     fn number(input: &str) -> nom::IResult<&str, u16> {
         map_res(
             delimited(space0, take_while1(|c: char| c.is_ascii_digit()), space0),
             |number: &str| number.parse(),
-        )(input)
+        )
+        .parse(input)
     }
 }

--- a/puzzles/2015/2015-08/src/part1.rs
+++ b/puzzles/2015/2015-08/src/part1.rs
@@ -4,7 +4,7 @@ use nom::{
     character::complete::anychar,
     combinator::map,
     multi::many0,
-    sequence::tuple,
+    Parser,
 };
 
 pub fn part_1(input: &str) -> usize {
@@ -30,31 +30,33 @@ impl Measurable for &str {
 
     fn memory_length(&self) -> usize {
         fn backslash(input: &str) -> nom::IResult<&str, usize> {
-            map(tag("\\\\"), |_| 1)(input)
+            map(tag("\\\\"), |_| 1).parse(input)
         }
 
         fn hexadecimal(input: &str) -> nom::IResult<&str, usize> {
             map(
-                tuple((
+                (
                     tag("\\x"),
                     take_while_m_n(2, 2, |c: char| c.is_ascii_hexdigit()),
-                )),
+                ),
                 |_| 1,
-            )(input)
+            )
+            .parse(input)
         }
 
         fn double_quote(input: &str) -> nom::IResult<&str, usize> {
-            map(tag("\\\""), |_| 1)(input)
+            map(tag("\\\""), |_| 1).parse(input)
         }
 
         fn character(input: &str) -> nom::IResult<&str, usize> {
-            map(anychar, |_| 1)(input)
+            map(anychar, |_| 1).parse(input)
         }
 
         let string = self.strip_prefix('"').unwrap().strip_suffix('"').unwrap();
 
-        let (_, numbers) =
-            many0(alt((backslash, hexadecimal, double_quote, character)))(string).unwrap();
+        let (_, numbers) = many0(alt((backslash, hexadecimal, double_quote, character)))
+            .parse(string)
+            .unwrap();
 
         numbers.iter().sum::<usize>()
     }

--- a/puzzles/2015/2015-09/src/common.rs
+++ b/puzzles/2015/2015-09/src/common.rs
@@ -1,6 +1,7 @@
 use std::{collections::HashMap, ops::Deref, str::FromStr};
 
 use itertools::Itertools;
+use nom::Parser;
 
 pub struct Router {
     network: HashMap<Location, HashMap<Location, Distance>>,
@@ -58,23 +59,24 @@ impl FromStr for Route {
             bytes::complete::tag,
             character::complete::{alpha1, digit1},
             combinator::{map, map_res},
-            sequence::tuple,
         };
 
         fn location(input: &str) -> nom::IResult<&str, Location> {
             map(alpha1, |name: &str| Location {
                 name: name.to_string(),
-            })(input)
+            })
+            .parse(input)
         }
 
-        let (_, (origin, _, destination, _, distance)) = tuple((
+        let (_, (origin, _, destination, _, distance)) = (
             location,
             tag(" to "),
             location,
             tag(" = "),
             map_res(digit1, |s: &str| s.parse()),
-        ))(string)
-        .map_err(|_| string.to_string())?;
+        )
+            .parse(string)
+            .map_err(|_| string.to_string())?;
 
         Ok(Self {
             origin,

--- a/puzzles/2015/2015-13/src/common.rs
+++ b/puzzles/2015/2015-13/src/common.rs
@@ -3,7 +3,7 @@ use nom::{
     bytes::complete::tag,
     character::complete::{alpha1, digit1},
     combinator::{map, map_res},
-    sequence::tuple,
+    Parser,
 };
 
 pub struct Relation {
@@ -14,30 +14,31 @@ pub struct Relation {
 
 pub fn relation(input: &str) -> nom::IResult<&str, Relation> {
     map(
-        tuple((
+        (
             alpha1,
             tag(" would "),
             map(
-                tuple((
+                (
                     alt((
-                        tuple((tag("gain "), map_res(digit1, |s: &str| s.parse::<isize>()))),
-                        tuple((
+                        (tag("gain "), map_res(digit1, |s: &str| s.parse::<isize>())),
+                        (
                             tag("lose "),
                             map_res(digit1, |s: &str| s.parse::<isize>().map(|i| -i)),
-                        )),
+                        ),
                     )),
                     tag(" happiness units"),
-                )),
+                ),
                 |((_, delta), _)| delta,
             ),
             tag(" by sitting next to "),
             alpha1,
             tag("."),
-        )),
+        ),
         |(person, _, delta, _, neighbor, _)| Relation {
             person: person.to_string(),
             neighbor: neighbor.to_string(),
             delta,
         },
-    )(input)
+    )
+    .parse(input)
 }


### PR DESCRIPTION
This pull request upgrades all dependencies to their latest (incompatible) version, and fixes all the errors that that results in. Notably this includes [`nom` version 8](https://unhandledexpression.com/nom-8/), and I want to express just how impressed I am by this new release. As you can see in the changes, I only had to add some `.parse()` and remove the use of `tuple()`, and it just works. Technically this new version is very cool, switching from a function-composing architecture (which was already nice) to a trait-based approach.